### PR TITLE
Custom disk in DownloadFileAction

### DIFF
--- a/src/Actions/DownloadFileAction.php
+++ b/src/Actions/DownloadFileAction.php
@@ -12,6 +12,8 @@ class DownloadFileAction implements ActionInterface
 
     protected $headers;
 
+    protected $disk;
+
     /**
      * Constructor to action.
      *
@@ -27,11 +29,18 @@ class DownloadFileAction implements ActionInterface
         $this->headers = $headers;
     }
 
+    public function disk(?string $disk): self
+    {
+        $this->disk = $disk;
+
+        return $this;
+    }
+
     /**
      * Execute Action.
      */
     public function run()
     {
-        return Storage::download($this->path, $this->name, $this->headers);
+        return Storage::disk($this->disk)->download($this->path, $this->name, $this->headers);
     }
 }

--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -5,7 +5,6 @@ namespace MagicLink;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use MagicLink\Actions\ActionInterface;

--- a/tests/Actions/DownloadFileTest.php
+++ b/tests/Actions/DownloadFileTest.php
@@ -2,7 +2,6 @@
 
 namespace MagicLink\Test\Actions;
 
-use Illuminate\Support\Facades\App;
 use MagicLink\Actions\DownloadFileAction;
 use MagicLink\MagicLink;
 use MagicLink\Test\TestCase;

--- a/tests/Actions/DownloadFileTest.php
+++ b/tests/Actions/DownloadFileTest.php
@@ -34,4 +34,18 @@ class DownloadFileTest extends TestCase
                 'attachment; filename=other.txt'
             );
     }
+
+    public function test_download_file_from_other_disk()
+    {
+        $magiclink = MagicLink::create(
+            (new DownloadFileAction('text_alternative.txt'))->disk('alternative')
+        );
+
+        $this->get($magiclink->url)
+            ->assertStatus(200)
+            ->assertHeader(
+                'content-disposition',
+                'attachment; filename=text_alternative.txt'
+            );
+    }
 }

--- a/tests/Actions/LoginTest.php
+++ b/tests/Actions/LoginTest.php
@@ -2,7 +2,6 @@
 
 namespace MagicLink\Test\Actions;
 
-use Illuminate\Support\Facades\App;
 use MagicLink\Actions\LoginAction;
 use MagicLink\MagicLink;
 use MagicLink\Test\TestCase;

--- a/tests/Actions/ResponseTest.php
+++ b/tests/Actions/ResponseTest.php
@@ -18,7 +18,6 @@ class ResponseTest extends TestCase
         $this->get($magiclink->url)
             ->assertStatus(302)
             ->assertRedirect(config('magiclink.url.redirect_default', '/'));
-
     }
 
     public function test_response_callable()

--- a/tests/Actions/ResponseTest.php
+++ b/tests/Actions/ResponseTest.php
@@ -2,7 +2,6 @@
 
 namespace MagicLink\Test\Actions;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use MagicLink\Actions\ResponseAction;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -2,7 +2,6 @@
 
 namespace MagicLink\Test;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use MagicLink\Actions\ResponseAction;
 use MagicLink\MagicLink;

--- a/tests/Events/MagicLinkWasVisitedTest.php
+++ b/tests/Events/MagicLinkWasVisitedTest.php
@@ -2,7 +2,6 @@
 
 namespace MagicLink\Test\Events;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use MagicLink\Actions\ResponseAction;
 use MagicLink\Events\MagicLinkWasVisited;

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -38,7 +38,6 @@ class FeatureTest extends TestCase
         $this->get('/create/redirect?redirectTo=/test&status=301')
             ->assertStatus(200);
 
-
         $this->get(MagicLink::first()->url)
             ->assertStatus(301)
             ->assertRedirect('/test');

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -2,7 +2,6 @@
 
 namespace MagicLink\Test;
 
-use Illuminate\Support\Facades\App;
 use MagicLink\MagicLink;
 
 class FeatureTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,6 +42,11 @@ abstract class TestCase extends Orchestra
 
         $app['config']->set('filesystems.disks.local.root', __DIR__.'/stubs/storage/app');
 
+        $app['config']->set('filesystems.disks.alternative', [
+            'driver' => 'local',
+            'root'   => __DIR__.'/stubs/storage/app_alternative',
+        ]);
+
         $app['config']->set('database.connections.sqlite', [
             'driver'   => 'sqlite',
             'database' => ':memory:',

--- a/tests/stubs/storage/app_alternative/text_alternative.txt
+++ b/tests/stubs/storage/app_alternative/text_alternative.txt
@@ -1,0 +1,1 @@
+private file alternative to download.


### PR DESCRIPTION
Add method `disk` to defined a disk to download.

Example:

```php
$action = new DownloadFileAction('text_alternative.txt');
$action->disk('ftp');

$magiclink = MagicLink::create($action);
```