### PR TITLE
Token length changes

### DIFF
--- a/config/magiclink.php
+++ b/config/magiclink.php
@@ -8,7 +8,8 @@ return [
         | Token size
         |--------------------------------------------------------------------------
         |
-        | Here you may specifiy the length of token to verify the identify.
+        | Here you may specify the length of token to verify the identify.
+        | Max value is 255 characters, it will be used if bigger value is set.
         |
         */
         'length' => 64,

--- a/databases/migrations/2017_07_06_000000_create_table_magic_links.php
+++ b/databases/migrations/2017_07_06_000000_create_table_magic_links.php
@@ -15,7 +15,7 @@ class CreateTableMagicLinks extends Migration
     {
         Schema::create(config('magiclink.magiclink_table', 'magic_links'), function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->string('token', 100);
+            $table->string('token', 255);
             $table->text('action');
             $table->unsignedTinyInteger('num_visits')->default(0);
             $table->unsignedTinyInteger('max_visits')->nullable();

--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -28,7 +28,9 @@ class MagicLink extends Model
 
     protected static function getTokenLength()
     {
-        return config('magiclink.token.length', 64) <= 255 ? config('magiclink.token.length', 64) : 255;
+        return config('magiclink.token.length', 64) <= 255
+            ? config('magiclink.token.length', 64)
+            : 255;
     }
 
     public function getActionAttribute($value)

--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -26,6 +26,11 @@ class MagicLink extends Model
         });
     }
 
+    protected static function getTokenLength()
+    {
+        return config('magiclink.token.length', 64) <= 255 ? config('magiclink.token.length', 64) : 255;
+    }
+
     public function getActionAttribute($value)
     {
         if ($this->getConnection()->getDriverName() === 'pgsql') {
@@ -66,7 +71,7 @@ class MagicLink extends Model
 
         $magiclink = new static();
 
-        $magiclink->token = Str::random(config('magiclink.token.length', 64));
+        $magiclink->token = Str::random(self::getTokenLength());
         $magiclink->available_at = $lifetime
                                     ? Carbon::now()->addMinute($lifetime)
                                     : null;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -18,6 +18,15 @@ class ConfigTest extends TestCase
         $this->assertEquals(10, strlen($this->getTokenFromUrl($url)));
     }
 
+    public function test_custom_token_length_bigger_than_max_value()
+    {
+        $this->app['config']->set('magiclink.token.length', 256);
+
+        $url = MagicLink::create(new ResponseAction())->url;
+
+        $this->assertEquals(255, strlen($this->getTokenFromUrl($url)));
+    }
+
     protected function getTokenFromUrl($url)
     {
         $parts = explode(':', $url);


### PR DESCRIPTION
Token length database column length is set to 255.
If bigger than the max value of token length is set, the max value will be used