### PR TITLE
Update phpdoc for MarkLink

### DIFF
--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -17,6 +17,7 @@ use MagicLink\Events\MagicLinkWasVisited;
  * @property Carbon|null $available_at
  * @property int|null $max_visits
  * @property \MagicLink\Actions\ActionAbstract $action
+ * @property-read string $url
  */
 class MagicLink extends Model
 {


### PR DESCRIPTION
Add missing phpdoc for the `$url` property which indicates it is readonly.