### PR TITLE
Add abort response

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,24 @@ Example:
     ],
 ```
 
+#### Abort
+
+To return a exception and let the framework handle the response,
+use class `MagicLink\Responses\AbortResponse::class`.
+Same `abort()`, you can send the arguments with options.
+
+Example:
+
+```php
+    'invalid_response' => [
+        'class'   => MagicLink\Responses\AbortResponse::class,
+        'options' => [
+            'message' => 'You Shall Not Pass!',
+            'status' => 403,
+        ],
+    ],
+```
+
 #### Redirect
 
 Define class `MagicLink\Responses\RedirectResponse::class` to

--- a/src/Responses/AbortResponse.php
+++ b/src/Responses/AbortResponse.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MagicLink\Responses;
+
+class AbortResponse implements ResponseContract
+{
+    public function __invoke($options = [])
+    {
+        abort(
+            $options['status'] ?? 403,
+            $options['message'] ?? '',
+            $options['headers'] ?? []
+        );
+    }
+}

--- a/tests/Responses/AbortResponseTest.php
+++ b/tests/Responses/AbortResponseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MagicLink\Test\Responses;
+
+use MagicLink\Test\TestCase;
+use MagicLink\Responses\AbortResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class AbortResponseTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->withoutExceptionHandling();
+        $this->expectException(HttpException::class);
+        
+        $this->app['config']->set(
+            'magiclink.invalid_response.class',
+            AbortResponse::class
+        );
+    }
+    
+    public function test_default_response()
+    {
+        $this->get('/magiclink/bad_token')
+            ->assertStatus(403)
+            ->assertSee('Forbidden');
+    }
+
+    public function test_custom_response()
+    {
+        $this->app['config']->set(
+            'magiclink.invalid_response.options',
+            [
+                'message' => 'You Shall Not Pass!',
+                'status' => 403,
+            ]
+        );
+
+        $this->get('/magiclink/bad_token')
+            ->assertStatus(403)
+            ->assertSee('You Shall Not Pass!');
+    }
+}


### PR DESCRIPTION
In case of an invalid response, I want to use the framework's own error pages. 

Therefore I added an AbortResponse which throws an HTTPException which is handled by the framework.