### PR TITLE
Publish migrations

### DIFF
--- a/src/MagicLinkServiceProvider.php
+++ b/src/MagicLinkServiceProvider.php
@@ -17,7 +17,9 @@ class MagicLinkServiceProvider extends ServiceProvider
             __DIR__.'/../config/magiclink.php' => config_path('magiclink.php'),
         ], 'config');
 
-        $this->loadMigrationsFrom(__DIR__.'/../databases/migrations');
+           $this->publishes([
+            __DIR__.'/../databases/migrations' => database_path('migrations'),
+        ], 'migrations');
 
         if ($this->mustLoadRoute()) {
             $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');


### PR DESCRIPTION
It seems to me that developers should copy migrations into their directory, there are two reasons for this
- First, my tests won't work - they don't create migrations from this package
- Second, I would like to look in the directory of migrations and think that this is the whole list of migrations which is available and it fits the database structure - but in this case I have to keep in mind that there are also migrations from another package



And should be added to the documentation of the publication of migrations