### PR TITLE
Add urlencoding to the colon in the magiclink url

### DIFF
--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -74,9 +74,10 @@ class MagicLink extends Model
     public function getUrlAttribute()
     {
         return url(sprintf(
-            '%s/%s:%s',
+            '%s/%s%s%s',
             config('magiclink.url.validate_path', 'magiclink'),
             $this->id,
+            urlencode(':'),
             $this->token
         ));
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -29,7 +29,7 @@ class ConfigTest extends TestCase
 
     protected function getTokenFromUrl($url)
     {
-        $parts = explode(':', $url);
+        $parts = explode(urlencode(':'), $url);
 
         return end($parts);
     }


### PR DESCRIPTION
Thanks for the great package @cesargb, we have been using it with great success! 🙂 

We have recently encountered an issue where certain email security products (Barracuda Sentinel for example) are invalidating the links by stripping out the `:` and everything after it, with means our links are missing the token entirely.

I believe if we were to `urlencode()` the separator the issue would no longer occur. 🤞

It should be safe to do as Laravel will urldecode any route parameters, which would transform the `%3A` to `:` as before.

I've been running the `urlencode()` on a local branch and i haven't noticed any issues. 👍 