### PR TITLE
Add base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ once the link is visited.
 - [Http Response](#http-response-action)
 - [Controller](#controller-action)
 - [Custom Action](#custom-action)
+- [Custom Base URL](#custom-base-url)
 
 ### Login Action
 
@@ -239,6 +240,18 @@ use MagicLink\MagicLink;
 $action = new MyCustomAction('Hello world');
 
 $urlToCustomAction = MagicLink::create($action)->url;
+```
+
+### Custom Base URL
+
+To set the base URL for a magic link, you can use the `baseUrl` method. This method ensures that the provided base URL has a trailing slash, making it ready for URL generation.
+
+```php
+$magiclink = MagicLink::create($action);
+
+$magiclink->baseUrl("http://example.com");
+
+$urlShowView = $magiclink->url; // http://example.com/magiclink/...
 ```
 
 ## Protect with an access code

--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -71,10 +71,19 @@ class MagicLink extends Model
                                         : serialize($value);
     }
 
-    public function getUrlAttribute()
+    public function baseUrl(?string $baseUrl): self
     {
+        $this->attributes['base_url'] = rtrim($baseUrl, '/') . '/';
+        return $this;
+    }
+
+    public function getUrlAttribute(): string
+    {
+        $baseUrl = rtrim($this->attributes['base_url'] ?? '', '/') . '/'; // Use the stored base_url or an empty string
+
         return url(sprintf(
-            '%s/%s%s%s',
+            '%s%s/%s%s%s',
+            $baseUrl,
             config('magiclink.url.validate_path', 'magiclink'),
             $this->id,
             urlencode(':'),

--- a/tests/MagicLinkTest.php
+++ b/tests/MagicLinkTest.php
@@ -120,4 +120,14 @@ class MagicLinkTest extends TestCase
     {
         $this->markTestSkipped();
     }
+
+    public function test_create_magiclink_with_custom_base_url()
+    {
+        $magiclink = MagicLink::create(new LoginAction(User::first()));
+
+        $custom_base_url = "http://example.com";
+        $magiclink->baseUrl($custom_base_url);
+        
+        $this->assertStringContainsString($custom_base_url, $magiclink->url);
+    }
 }


### PR DESCRIPTION
Introduces a custom base URL attribute for the **MagicLink** model, enhancing flexibility in URL generation. This feature ensures the generated URLs have the correct format by automatically handling trailing slashes. Includes corresponding tests to validate the functionality.