### PR TITLE
Cast MagicLink's UUID to a string when initially set

### DIFF
--- a/src/MagicLink.php
+++ b/src/MagicLink.php
@@ -44,7 +44,7 @@ class MagicLink extends Model
         parent::boot();
 
         static::creating(function ($model) {
-            $model->id = Str::uuid();
+            $model->id = (string) Str::uuid();
         });
     }
 


### PR DESCRIPTION
Resolves #112. 