### PR TITLE
Prevent head requests triggering run on null

### DIFF
--- a/src/Middlewares/MagiclinkMiddleware.php
+++ b/src/Middlewares/MagiclinkMiddleware.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Http\Request;
 use MagicLink\MagicLink;
 use MagicLink\Responses\Response;
-use Illuminate\Http\Response as IlluminateResponse;
 
 class MagiclinkMiddleware
 {
@@ -16,8 +15,8 @@ class MagiclinkMiddleware
 
         $magicLink = MagicLink::getValidMagicLinkByToken($token);
 
-        if($request->method() === 'HEAD') {
-            return new IlluminateResponse(null, ($magicLink) ? 200 : 404);
+        if ($request->method() === 'HEAD') {
+            return response()->noContent(($magicLink) ? 200 : 404);
         }
 
         if (! $magicLink) {

--- a/src/Middlewares/MagiclinkMiddleware.php
+++ b/src/Middlewares/MagiclinkMiddleware.php
@@ -6,18 +6,19 @@ use Closure;
 use Illuminate\Http\Request;
 use MagicLink\MagicLink;
 use MagicLink\Responses\Response;
+use Illuminate\Http\Response as IlluminateResponse;
 
 class MagiclinkMiddleware
 {
     public function handle(Request $request, Closure $next)
     {
-        if($request->method() === 'HEAD') {
-            return $next($request);
-        }
-
         $token = (string) $request->route('token');
 
         $magicLink = MagicLink::getValidMagicLinkByToken($token);
+
+        if($request->method() === 'HEAD') {
+            return new IlluminateResponse(null, ($magicLink) ? 200 : 404);
+        }
 
         if (! $magicLink) {
             return $this->badResponse();

--- a/tests/Middlewares/MagicLinkMiddlewareTest.php
+++ b/tests/Middlewares/MagicLinkMiddlewareTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MagicLink\Test\Responses;
+
+use MagicLink\Actions\LoginAction;
+use MagicLink\MagicLink;
+use MagicLink\Test\TestCase;
+use MagicLink\Test\TestSupport\User;
+
+class MagicLinkMiddlewareTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_head_request_returns_404_when_magiclink_is_invalid()
+    {
+        $this->head('/magiclink/bad_token')
+            ->assertStatus(404);
+    }
+
+    public function test_head_request_returns_200_when_magiclink_is_valid()
+    {
+        $magiclink = MagicLink::create(new LoginAction(User::first()));
+
+        $this->head($magiclink->url)
+            ->assertStatus(200);
+    }
+}

--- a/tests/Middlewares/MagicLinkMiddlewareTest.php
+++ b/tests/Middlewares/MagicLinkMiddlewareTest.php
@@ -9,11 +9,6 @@ use MagicLink\Test\TestSupport\User;
 
 class MagicLinkMiddlewareTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function test_head_request_returns_404_when_magiclink_is_invalid()
     {
         $this->head('/magiclink/bad_token')


### PR DESCRIPTION
Resolves #106.

I'm fairly confident that these errors are being triggered by HEAD requests. I've verified this by generating a magiclink in my application, deleting the entry inside `magic_links` then performing a `HEAD` request to the deleted magiclink url.

After adjusting the `MagiclinkMiddleware` so it returns a 200 or 404 based on the validity of the Magiclink, this error no longer occurs. 👍 