### PR TITLE
Update composer.json to allow laravel/serializable-closure:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/container": "^9.0|^10.0|^11.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "illuminate/database": "^9.0|^10.0|^11.0",
-        "laravel/serializable-closure": "^1.0"
+        "laravel/serializable-closure": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I had to downgrade laravel/serializable-closure since this package only allows ^1.0 and laravel/serializable-closure released v2.0.0 3 weeks ago.

Ran the current test with no issues using laravel/serializable-closure:^2.0