### PR TITLE
Add indexes to available_at and max_visits

### DIFF
--- a/databases/migrations/2024_12_25_000000_add_indexes_to_magic_links_table.php
+++ b/databases/migrations/2024_12_25_000000_add_indexes_to_magic_links_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexesToMagicLinksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('magic_links', function (Blueprint $table) {
+            $table->index('available_at');
+            $table->index('max_visits');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('magic_links', function (Blueprint $table) {
+            $table->dropIndex('magic_links_available_at_index');
+            $table->dropIndex('magic_links_max_visits_index');
+        });
+    }
+}


### PR DESCRIPTION
# Add indexes to available_at and max_visits

## Reason

The self-cleaning process of the magiclink logs causes latency when the logs do not expire.

see: #120 

> [!CAUTION]
> Stack migration adding indexes may take 2 or more seconds for a volume of 400,000 records. 

## Install

```bash
composer update cesargb/laravel-magiclink
php artisan vendor:publish --provider="MagicLink\MagicLinkServiceProvider" --tag="migrations"
php artisan migrate
```



