### PR TITLE
add migration for base_url

### DIFF
--- a/databases/migrations/2025_02_28_000000_add_base_url_to_magic_links_table.php
+++ b/databases/migrations/2025_02_28_000000_add_base_url_to_magic_links_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('magic_links', function (Blueprint $table) {
+            $table->string('base_url')->nullable()->after('action');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasColumn('magic_links', 'base_url')) {
+            Schema::table('magic_links', function (Blueprint $table) {
+                $table->dropColumn('base_url');
+            });
+        }
+    }
+};


### PR DESCRIPTION
It would appear that the baseUrl feature requires a database column that isn't included in the migrations.